### PR TITLE
Improved a registration of JS engines

### DIFF
--- a/Mvc5Sample/App_Start/ReactConfig.cs
+++ b/Mvc5Sample/App_Start/ReactConfig.cs
@@ -9,26 +9,21 @@ using React;
 
 namespace Mvc5Sample
 {
-	public static class ReactConfig
-	{
-		public static void Configure()
-		{
-            ReactSiteConfiguration.Configuration
-		        .SetLoadBabel(false)
-                .SetLoadReact(false)
-		        .AddScriptWithoutTransform("~/js/server.js");
-
-		    JsEngineSwitcher engineSwitcher = JsEngineSwitcher.Instance;
-
-		    engineSwitcher.EngineFactories.Clear();
-
-		    engineSwitcher.EngineFactories.Add(new V8JsEngineFactory());
-		    engineSwitcher.DefaultEngineName = V8JsEngine.EngineName;
-
-
-            engineSwitcher.EngineFactories.Add(new ChakraCoreJsEngineFactory());
+    public static class ReactConfig
+    {
+        public static void Configure()
+        {
+            JsEngineSwitcher engineSwitcher = JsEngineSwitcher.Instance;
+            engineSwitcher.EngineFactories
+                .AddV8()
+                .AddChakraCore()
+                ;
             engineSwitcher.DefaultEngineName = ChakraCoreJsEngine.EngineName;
 
+            ReactSiteConfiguration.Configuration
+                .SetLoadBabel(false)
+                .SetLoadReact(false)
+                .AddScriptWithoutTransform("~/js/server.js");
         }
     }
 }


### PR DESCRIPTION
Hello, Daniil!

> engineSwitcher.EngineFactories.Clear();

In this case, clearing the list of factories does not make sense, because the ReactJS.NET is registering default factories in the [`EnsureJsEnginesRegistered`](https://github.com/reactjs/React.NET/blob/2752d9d66ea7a9cffefb2748a02e20695e90de30/src/React.Core/JavaScriptEngineFactory.cs#L359-L391) method of <code title="React.JavaScriptEngineFactory">JavaScriptEngineFactory</code> class. This method is called only when an instance of the <code title="React.JavaScriptEngineFactory">JavaScriptEngineFactory</code> class (in your case it's <code title="JsPoolOptimization.AfishaJavaScriptEngineFactory">AfishaJavaScriptEngineFactory</code> class) is created. In any case, contents of the `App_Start/ReactConfig.cs` file will be executed before contents of the `Global.asax` file due the `[assembly: WebActivatorEx.PreApplicationStartMethod(…)]` attribute.